### PR TITLE
Update policy and minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(bigmac)
+cmake_policy(SET CMP0135 NEW)
 if(CMAKE_BUILD_TYPE STREQUAL "")
   set(CMAKE_BUILD_TYPE "Release")
 endif()

--- a/bigmac/CMakeLists.txt
+++ b/bigmac/CMakeLists.txt
@@ -1,18 +1,18 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(bigmac)
 
 # Set BigMac Version
 set(BIGMAC_MAJOR_VERSION 0)
 set(BIGMAC_MINOR_VERSION 0)
-set(BIGMAC_PATCH_VERSION 6)
+set(BIGMAC_PATCH_VERSION 7)
 set(BIGMAC_VERSION
   ${BIGMAC_MAJOR_VERSION}.${BIGMAC_MINOR_VERSION}.${BIGMAC_PATCH_VERSION}
 )
 
 # Set latest version of macOS system
-set(MACOS_LATEST "12.6")
-set(DARWIN_LATEST "12.5.0")
-set(XCODE_LATEST "14.1")
+set(MACOS_LATEST "15.4")
+set(DARWIN_LATEST "24.4")
+set(XCODE_LATEST "16.3")
 
 export(PACKAGE bigmac)
 


### PR DESCRIPTION
- Added CMake policy
- Updated minimum CMake version to 3.5
- Updated macOS latest versions
- Set patch version to 0.0.7 